### PR TITLE
docs: README: Remove extra `/` in link

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,4 +66,4 @@ Options:
 ## Special Thanks
 
 - https://github.com/fastfetch-cli/fastfetch
-- https://github.com/hykilpikonna/hyfetch/
+- https://github.com/hykilpikonna/hyfetch


### PR DESCRIPTION
This makes it more consistent with the previous link.