### PR TITLE
Cargo.toml: version is 0.2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name="mirafetch"
-version="0.1.0"
+version="0.2.0"
 edition="2021"
 description="A Rust reimplementation of Hyfetch wih a focus on speed"
 license-file="LICENSE.md"


### PR DESCRIPTION
This fixes the following:

```console
$ mirafetch --version
mirafetch 0.1.0
```